### PR TITLE
Fix `get_bitinformation(label)`

### DIFF
--- a/bitinformation_pipeline/bitinformation_pipeline.py
+++ b/bitinformation_pipeline/bitinformation_pipeline.py
@@ -96,6 +96,7 @@ def get_bitinformation(ds, label=None, overwrite=False, **kwargs):
             logging.debug(f"get_bitinformation(X{kwargs_str})")
             info_per_bit[var] = jl.eval(f"get_bitinformation(X{kwargs_str})")
         with open(label + ".json", "w") as f:
+            logging.debug(f"Save bitinformation to {label+'.json'}")
             json.dump(info_per_bit, f, cls=JsonCustomEncoder)
     return info_per_bit
 
@@ -105,7 +106,8 @@ def load_bitinformation(label):
     label_file = label + ".json"
     if os.path.exists(label_file):
         with open(label_file) as f:
-            info_per_bit = json.open(f)
+            logging.debug(f"Load bitinformation from {label+'.json'}")
+            info_per_bit = json.load(f)
         print(info_per_bit)
         return info_per_bit
     else:

--- a/tests/test_get_bitinformation.py
+++ b/tests/test_get_bitinformation.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 """Tests for `bitinformation_pipeline` package."""
+import os
 
 import numpy as np
 import xarray as xr

--- a/tests/test_get_bitinformation.py
+++ b/tests/test_get_bitinformation.py
@@ -62,3 +62,12 @@ def test_get_bitinformation_masked_value():
     bitinfo = bp.get_bitinformation(ds, dim="x")
     bitinfo_no_mask = bp.get_bitinformation(ds, dim="x", masked_value="nothing")
     bitinfo_assert_different(bitinfo, bitinfo_no_mask)
+
+
+def test_get_bitinformation_label():
+    """Test bp.get_bitinformation serializes when label given."""
+    ds = xr.tutorial.load_dataset("rasm")
+    bp.get_bitinformation(ds, dim="x", label="rasm")
+    assert os.path.exists("rasm.json")
+    # second call should be faster
+    bp.get_bitinformation(ds, dim="x", label="rasm")


### PR DESCRIPTION
- This fixes the loading of calculated bitinformation
- `label`s are no longer generated as this is complicated for datasets that are not based on a single file. It's just up to the user to provide a meaningful `label`
- closes #24 