### PR TITLE
Fix visualization of 99/100 percent keepbits

### DIFF
--- a/bitinformation_pipeline/bitinformation_pipeline.py
+++ b/bitinformation_pipeline/bitinformation_pipeline.py
@@ -180,7 +180,8 @@ def plot_bitinformation(ds, bitinfo):
     infbits100_dict = get_keepbits(ds, bitinfo, 0.999999999)
 
     ICnan = np.zeros((nvars, 64))
-    infbits = infbits100 = np.zeros(nvars)
+    infbits = np.zeros(nvars)
+    infbits100 = np.zeros(nvars)
     ICnan[:, :] = np.nan
     for v, var in enumerate(varnames):
         ic = bitinfo[var]


### PR DESCRIPTION
It works now. Stupid mistake.
![image](https://user-images.githubusercontent.com/43613877/162235671-675efafa-4263-4b39-8d72-bb4c6aa4a870.png)

The keepbits of the chosen example dataset are however the same for 0.99 and 0.999999.
The dataset `ds = xr.tutorial.load_dataset("air_temperature")` shows the differences:

![image](https://user-images.githubusercontent.com/43613877/162236985-04499ade-2684-4d58-a0f2-f543ed5123ff.png)

I prefer to rather show several variables in the example notebook then showing one where the keepbits are different.