### PR TITLE
fix `to_compressed_netcdf` if `time_dim` not in variable

### DIFF
--- a/bitinformation_pipeline/save_compressed.py
+++ b/bitinformation_pipeline/save_compressed.py
@@ -9,18 +9,17 @@ def get_chunksizes(da, for_cdo=False, time_dim="time", chunks=None):
     if chunks:  # use new chunksizes
         return da.chunk(chunks).data.chunksize
     if for_cdo:  # take shape as chunksize and ensure time chunksize 1
-        time_axis_num = da.get_axis_num(time_dim)
-        chunksize = da.data.chunksize if is_dask_collection(da) else da.shape
-        # https://code.mpimet.mpg.de/boards/2/topics/12598
-        chunksize = list(chunksize)
-        chunksize[time_axis_num] = 1
-        chunksize = tuple(chunksize)
-        return chunksize
+        if time_dim in da.dims:
+            time_axis_num = da.get_axis_num(time_dim)
+            chunksize = da.data.chunksize if is_dask_collection(da) else da.shape
+            # https://code.mpimet.mpg.de/boards/2/topics/12598
+            chunksize = list(chunksize)
+            chunksize[time_axis_num] = 1
+            chunksize = tuple(chunksize)
+            return chunksize
+         else get_chunksizes(da, for_cdo=False, time_dim=time_dim)
     else:
-        if is_dask_collection(da.data):
-            return da.data.chunksize
-        else:
-            return da.shape
+        return da.data.chunksize if is_dask_collection(da.data) else da.shape
 
 
 def get_compress_encoding(

--- a/bitinformation_pipeline/save_compressed.py
+++ b/bitinformation_pipeline/save_compressed.py
@@ -17,7 +17,8 @@ def get_chunksizes(da, for_cdo=False, time_dim="time", chunks=None):
             chunksize[time_axis_num] = 1
             chunksize = tuple(chunksize)
             return chunksize
-        else get_chunksizes(da, for_cdo=False, time_dim=time_dim)
+        else:
+            return get_chunksizes(da, for_cdo=False, time_dim=time_dim)
     else:
         return da.data.chunksize if is_dask_collection(da.data) else da.shape
 

--- a/bitinformation_pipeline/save_compressed.py
+++ b/bitinformation_pipeline/save_compressed.py
@@ -17,7 +17,7 @@ def get_chunksizes(da, for_cdo=False, time_dim="time", chunks=None):
             chunksize[time_axis_num] = 1
             chunksize = tuple(chunksize)
             return chunksize
-         else get_chunksizes(da, for_cdo=False, time_dim=time_dim)
+        else get_chunksizes(da, for_cdo=False, time_dim=time_dim)
     else:
         return da.data.chunksize if is_dask_collection(da.data) else da.shape
 

--- a/tests/test_save_compressed.py
+++ b/tests/test_save_compressed.py
@@ -20,7 +20,7 @@ def test_get_compress_encoding_for_cdo(rasm, for_cdo):
 
 @pytest.mark.parametrize("dask", [True, False])
 def test_to_compressed_netcdf(rasm, dask):
-    """Test bitinformation_pipeline end to end."""
+    """Test to_compressed_netcdf reduces size on disk."""
     ds = rasm
     if dask:
         ds = ds.chunk("auto")
@@ -32,3 +32,11 @@ def test_to_compressed_netcdf(rasm, dask):
     ori_size = os.path.getsize(f"{label}.nc")
     compressed_size = os.path.getsize(f"{label}_compressed.nc")
     assert compressed_size < ori_size
+
+
+def test_to_compressed_netcdf_for_cdo_no_time_dim_var(rasm):
+    """Test to_compressed_netcdf if `for_cdo=True` and one var without `time_dim`."""
+    ds = rasm
+    ds["air_mean"]=ds["air"].isel(time=0)
+    ds.to_compressed_netcdf("test.nc", for_cdo=True)
+    

--- a/tests/test_save_compressed.py
+++ b/tests/test_save_compressed.py
@@ -34,8 +34,9 @@ def test_to_compressed_netcdf(rasm, dask):
     assert compressed_size < ori_size
 
 
-def test_to_compressed_netcdf_for_cdo_no_time_dim_var(rasm):
+def test_to_compressed_netcdf_for_cdo_no_time_dim_var(air_temperature):
     """Test to_compressed_netcdf if `for_cdo=True` and one var without `time_dim`."""
-    ds = rasm
+    ds = air_temperature
     ds["air_mean"] = ds["air"].isel(time=0)
     ds.to_compressed_netcdf("test.nc", for_cdo=True)
+    os.remove("test.nc")

--- a/tests/test_save_compressed.py
+++ b/tests/test_save_compressed.py
@@ -37,6 +37,5 @@ def test_to_compressed_netcdf(rasm, dask):
 def test_to_compressed_netcdf_for_cdo_no_time_dim_var(rasm):
     """Test to_compressed_netcdf if `for_cdo=True` and one var without `time_dim`."""
     ds = rasm
-    ds["air_mean"]=ds["air"].isel(time=0)
+    ds["air_mean"] = ds["air"].isel(time=0)
     ds.to_compressed_netcdf("test.nc", for_cdo=True)
-    


### PR DESCRIPTION
happens for ICON output with vars such as `wet_c` or `wet_e`. should be highly compressible vars
```
<xarray.Dataset>
Dimensions:                         (ncells: 3729001, ncells_2: 5612762,
                                     depth: 128, depth_2: 129, lev: 1, time: 1)
Coordinates:
    clon                            (ncells) float32 ...
    clat                            (ncells) float32 ...
    elon                            (ncells_2) float32 ...
    elat                            (ncells_2) float32 ...
  * depth                           (depth) float64 5.5 15.5 ... 6.262e+03
  * depth_2                         (depth_2) float64 0.0 11.0 ... 6.362e+03
  * lev                             (lev) float64 0.0
  * time                            (time) datetime64[ns] 2000-04-01
Dimensions without coordinates: ncells, ncells_2
Data variables: (12/36)
    zos                             (ncells, time) float32 ...
    to                              (ncells, time, depth) float32 ...
    so                              (ncells, time, depth) float32 ...
    w                               (ncells, time, depth_2) float32 ...
    wet_c                           (ncells, depth) float32 ...
    wet_e                           (ncells_2, depth) float32 ...
```