### PR TITLE
`get_keepbits(inflevel=1.)` return max keepbits

### DIFF
--- a/bitinformation_pipeline/bitinformation_pipeline.py
+++ b/bitinformation_pipeline/bitinformation_pipeline.py
@@ -170,6 +170,8 @@ def get_keepbits(info_per_bit, inflevel=0.99):
     {'air': 7}
     >>> bp.get_keepbits(info_per_bit, inflevel=0.99999999)
     {'air': 14}
+    >>> bp.get_keepbits(info_per_bit, inflevel=1.)
+    {'air': 23}
     """
     keepmantissabits = {}
     for v, ic in info_per_bit.items():

--- a/bitinformation_pipeline/bitinformation_pipeline.py
+++ b/bitinformation_pipeline/bitinformation_pipeline.py
@@ -175,8 +175,8 @@ def get_keepbits(info_per_bit, inflevel=0.99):
     """
     keepmantissabits = {}
     if isinstance(inflevel, (int,float)):
-        if inflevel <= 0 or > inflevel > 1.:
-            raise ValueError("Please provide `inflevel` from interval (0.,1.]")
+        if inflevel < 0 or inflevel > 1.:
+            raise ValueError("Please provide `inflevel` from interval [0.,1.]")
     for v, ic in info_per_bit.items():
         if inflevel == 1.:
             keepmantissabits[v] = len(ic) - NMBITS[len(ic)]

--- a/bitinformation_pipeline/bitinformation_pipeline.py
+++ b/bitinformation_pipeline/bitinformation_pipeline.py
@@ -174,19 +174,25 @@ def get_keepbits(info_per_bit, inflevel=0.99):
     {'air': 23}
     """
     keepmantissabits = {}
+    if isinstance(inflevel, (int,float)):
+        if inflevel <= 0 or > inflevel > 1.:
+            raise ValueError("Please provide `inflevel` from interval (0.,1.]")
     for v, ic in info_per_bit.items():
-        # set below threshold to zero
-        # use something a bit bigger than maximum of the last 4 bits
-        threshold = 1.5 * np.max(ic[-4:])
-        ic_over_threshold = np.where(ic < threshold, 0, ic)
-        ic_over_threshold_cum = np.nancumsum(ic_over_threshold)  # CDF
-        # normed CDF
-        ic_over_threshold_cum_normed = ic_over_threshold_cum / ic_over_threshold_cum[-1]
-        # return mantissabits to keep therefore subtract sign and exponent bits
-        il = inflevel[v] if isinstance(inflevel, dict) else inflevel
-        keepmantissabits[v] = (
-            np.argmax(ic_over_threshold_cum_normed > il) + 1 - NMBITS[len(ic)]
-        )
+        if inflevel == 1.:
+            keepmantissabits[v] = len(ic) - NMBITS[len(ic)]
+        else:
+            # set below threshold to zero
+            # use something a bit bigger than maximum of the last 4 bits
+            threshold = 1.5 * np.max(ic[-4:])
+            ic_over_threshold = np.where(ic < threshold, 0, ic)
+            ic_over_threshold_cum = np.nancumsum(ic_over_threshold)  # CDF
+            # normed CDF
+            ic_over_threshold_cum_normed = ic_over_threshold_cum / ic_over_threshold_cum[-1]
+            # return mantissabits to keep therefore subtract sign and exponent bits
+            il = inflevel[v] if isinstance(inflevel, dict) else inflevel
+            keepmantissabits[v] = (
+                np.argmax(ic_over_threshold_cum_normed > il) + 1 - NMBITS[len(ic)]
+            )
     return keepmantissabits
 
 

--- a/bitinformation_pipeline/bitinformation_pipeline.py
+++ b/bitinformation_pipeline/bitinformation_pipeline.py
@@ -177,7 +177,7 @@ def get_keepbits(info_per_bit, inflevel=0.99):
         # use something a bit bigger than maximum of the last 4 bits
         threshold = 1.5 * np.max(ic[-4:])
         ic_over_threshold = np.where(ic < threshold, 0, ic)
-        ic_over_threshold_cum = np.cumsum(ic_over_threshold)  # CDF
+        ic_over_threshold_cum = np.nancumsum(ic_over_threshold)  # CDF
         # normed CDF
         ic_over_threshold_cum_normed = ic_over_threshold_cum / ic_over_threshold_cum[-1]
         # return mantissabits to keep therefore subtract sign and exponent bits

--- a/bitinformation_pipeline/bitinformation_pipeline.py
+++ b/bitinformation_pipeline/bitinformation_pipeline.py
@@ -214,6 +214,8 @@ def _get_keepbits(ds, info_per_bit, inflevel=0.99):
     {'air': 7}
     >>> bp._get_keepbits(ds, info_per_bit, inflevel=0.99999999)
     {'air': 14}
+    >>> bp._get_keepbits(ds, info_per_bit, inflevel=1.)
+    {'air': 23}
     """
 
     def get_inflevel(var, inflevel):

--- a/bitinformation_pipeline/bitinformation_pipeline.py
+++ b/bitinformation_pipeline/bitinformation_pipeline.py
@@ -214,7 +214,7 @@ def _get_keepbits(ds, info_per_bit, inflevel=0.99):
     {'air': 7}
     >>> bp._get_keepbits(ds, info_per_bit, inflevel=0.99999999)
     {'air': 14}
-    >>> bp._get_keepbits(ds, info_per_bit, inflevel=1.)
+    >>> bp._get_keepbits(ds, info_per_bit, inflevel=1.0)
     {'air': 23}
     """
 

--- a/bitinformation_pipeline/bitinformation_pipeline.py
+++ b/bitinformation_pipeline/bitinformation_pipeline.py
@@ -170,7 +170,7 @@ def get_keepbits(info_per_bit, inflevel=0.99):
     {'air': 7}
     >>> bp.get_keepbits(info_per_bit, inflevel=0.99999999)
     {'air': 14}
-    >>> bp.get_keepbits(info_per_bit, inflevel=1.)
+    >>> bp.get_keepbits(info_per_bit, inflevel=1.0)
     {'air': 23}
     """
     keepmantissabits = {}

--- a/bitinformation_pipeline/bitinformation_pipeline.py
+++ b/bitinformation_pipeline/bitinformation_pipeline.py
@@ -215,7 +215,7 @@ def _get_keepbits(ds, info_per_bit, inflevel=0.99):
     >>> bp._get_keepbits(ds, info_per_bit, inflevel=0.99999999)
     {'air': 14}
     >>> bp._get_keepbits(ds, info_per_bit, inflevel=1.0)
-    {'air': 23}
+    {'air': -8}
     """
 
     def get_inflevel(var, inflevel):

--- a/bitinformation_pipeline/bitinformation_pipeline.py
+++ b/bitinformation_pipeline/bitinformation_pipeline.py
@@ -174,11 +174,11 @@ def get_keepbits(info_per_bit, inflevel=0.99):
     {'air': 23}
     """
     keepmantissabits = {}
-    if isinstance(inflevel, (int,float)):
-        if inflevel < 0 or inflevel > 1.:
+    if isinstance(inflevel, (int, float)):
+        if inflevel < 0 or inflevel > 1.0:
             raise ValueError("Please provide `inflevel` from interval [0.,1.]")
     for v, ic in info_per_bit.items():
-        if inflevel == 1.:
+        if inflevel == 1.0:
             keepmantissabits[v] = len(ic) - NMBITS[len(ic)]
         else:
             # set below threshold to zero
@@ -187,7 +187,9 @@ def get_keepbits(info_per_bit, inflevel=0.99):
             ic_over_threshold = np.where(ic < threshold, 0, ic)
             ic_over_threshold_cum = np.nancumsum(ic_over_threshold)  # CDF
             # normed CDF
-            ic_over_threshold_cum_normed = ic_over_threshold_cum / ic_over_threshold_cum[-1]
+            ic_over_threshold_cum_normed = (
+                ic_over_threshold_cum / ic_over_threshold_cum[-1]
+            )
             # return mantissabits to keep therefore subtract sign and exponent bits
             il = inflevel[v] if isinstance(inflevel, dict) else inflevel
             keepmantissabits[v] = (


### PR DESCRIPTION
I get unexpected -8 from random numbers, where I'd expect 23 as `keepbits`. This implements returning max keepbits when inflevel is `1.0`

before:
`bp.get_keepbits(info_per_bit, inflevel=1.) # {'air': -8}`

I'd expect:
`bp.get_keepbits(info_per_bit, inflevel=1.) # {'air': 23}`

without changing:
`bp._get_keepbits(ds, info_per_bit, inflevel=0.99999) # {'air': 23}`

but still:
`bp._get_keepbits(ds, info_per_bit, inflevel=1.) # {'air': -8}`